### PR TITLE
Update SPPFixedBinaryEncoder.java

### DIFF
--- a/CCSDS_MAL_TRANSPORT_SPP/src/main/java/esa/mo/mal/encoder/spp/SPPFixedBinaryEncoder.java
+++ b/CCSDS_MAL_TRANSPORT_SPP/src/main/java/esa/mo/mal/encoder/spp/SPPFixedBinaryEncoder.java
@@ -248,7 +248,7 @@ public class SPPFixedBinaryEncoder extends GENEncoder
   {
     try
     {
-      if (null != value)
+      if ((null != value) && (value.getValue() != null))
       {
         outputStream.addNotNull();
         encodeIdentifier(value);


### PR DESCRIPTION
Updated the Nullable Identifier method to cope with Identifiers that are not null but have a null String object inside.