### PR TITLE
Meaningful error message for null in non-nullable fields

### DIFF
--- a/CCSDS_MAL_ENCODING_GEN/src/main/java/esa/mo/mal/encoder/gen/GENEncoder.java
+++ b/CCSDS_MAL_ENCODING_GEN/src/main/java/esa/mo/mal/encoder/gen/GENEncoder.java
@@ -727,7 +727,14 @@ public abstract class GENEncoder implements MALListEncoder
   @Override
   public void encodeElement(final Element value) throws MALException
   {
-    value.encode(this);
+    if (null != value)
+    {
+      value.encode(this);
+    }
+    else
+    {
+      throw new MALException("The encoding failed because a null value was inserted in a non-nullable field.");
+    }
   }
 
   @Override


### PR DESCRIPTION
The code hits a null pointer exception when it tries to encode a null value in non-nullable field. This is ok but the error message should be clear. The proposed change improves this.