### PR TITLE
Added a setter on the InputReader class

### DIFF
--- a/CCSDS_MAL_ENCODING_BINARY/src/main/java/esa/mo/mal/encoder/binary/BinaryDecoder.java
+++ b/CCSDS_MAL_ENCODING_BINARY/src/main/java/esa/mo/mal/encoder/binary/BinaryDecoder.java
@@ -361,6 +361,11 @@ public class BinaryDecoder extends GENDecoder
       this.contentLength = length;
     }
 
+    public void setForceRealloc(boolean forceRealloc)
+    {
+      this.forceRealloc = forceRealloc;
+    }
+    
     public byte get8() throws MALException
     {
       checkBuffer(1);


### PR DESCRIPTION
The TCPIPSplitBufferHolder class will need to set the forceRealloc flag.
Previously, forceRealloc could be directly reached but now it can't because of this refactoring:
https://github.com/esa/CCSDS_MO_TRANS/commit/67398139f1299ca368d4e2157718109a24501d2b

The setter would be enough to reach it.