### PR TITLE
Duplicate logging / Typo

### DIFF
--- a/CCSDS_MAL_TRANSPORT_RMI/src/main/java/esa/mo/mal/transport/rmi/RMITransport.java
+++ b/CCSDS_MAL_TRANSPORT_RMI/src/main/java/esa/mo/mal/transport/rmi/RMITransport.java
@@ -113,7 +113,7 @@ public class RMITransport extends GENTransport<byte[], byte[]>
     }
 
     portNumber = iRmiPort;
-    RLOGGER.log(Level.INFO, "RMI Creating registory on port {0}", portNumber);
+    RLOGGER.log(Level.FINE, "RMI Creating registry on port {0}", portNumber);
 
     super.init();
 
@@ -121,7 +121,7 @@ public class RMITransport extends GENTransport<byte[], byte[]>
     {
       ourRMIinterface = new RMIReceiveImpl(this);
       registry.rebind(String.valueOf(portNumber), ourRMIinterface);
-      RLOGGER.log(Level.INFO, "RMI Bound to registory on port {0}", portNumber);
+      RLOGGER.log(Level.INFO, "RMI Bound to registry on port {0}", portNumber);
     }
     catch (RemoteException ex)
     {


### PR DESCRIPTION
Upon startup, we received 2 messages:
Jan 05, 2017 10:22:57 AM esa.mo.mal.transport.rmi.RMITransport init
INFO: RMI Creating registory on port x
Jan 05, 2017 10:22:57 AM esa.mo.mal.transport.rmi.RMITransport init
INFO: RMI Bound to registory on port x