### PR TITLE
Update URI examples in code comments

### DIFF
--- a/CCSDS_MAL_TRANSPORT_GEN/src/main/java/esa/mo/mal/transport/gen/GENReceptionHandler.java
+++ b/CCSDS_MAL_TRANSPORT_GEN/src/main/java/esa/mo/mal/transport/gen/GENReceptionHandler.java
@@ -38,7 +38,7 @@ public interface GENReceptionHandler
   /**
    * Setter method for the remote URI of this handler
    *
-   * @param newURI the remote root URI, i.e. tcpip://10.0.0.1:61617
+   * @param newURI the remote root URI, i.e. maltcp://10.0.0.1:61617
    */
   public void setRemoteURI(String newURI);
 

--- a/CCSDS_MAL_TRANSPORT_GEN/src/main/java/esa/mo/mal/transport/gen/GENTransport.java
+++ b/CCSDS_MAL_TRANSPORT_GEN/src/main/java/esa/mo/mal/transport/gen/GENTransport.java
@@ -482,7 +482,7 @@ public abstract class GENTransport<I, O> implements MALTransport
               new MALStandardError(MALHelper.DESTINATION_UNKNOWN_ERROR_NUMBER, "URI To field must not be null"), qosProperties);
     }
     
-    // get the root URI, (e.g. tcpip://10.0.0.1:61616 )
+    // get the root URI, (e.g. maltcp://10.0.0.1:61616 )
     String destinationURI = msg.getHeader().getURITo().getValue();
     String remoteRootURI = getRootURI(destinationURI);
 
@@ -877,8 +877,8 @@ public abstract class GENTransport<I, O> implements MALTransport
    * Returns the "root" URI from the full URI. The root URI only contains the protocol and the main destination and is something
    * unique for all URIs of the same MAL.
    *
-   * @param fullURI the full URI, for example tcpip://10.0.0.1:61616-serviceXYZ
-   * @return the root URI, for example tcpip://10.0.0.1:61616
+   * @param fullURI the full URI, for example maltcp://10.0.0.1:61616-serviceXYZ
+   * @return the root URI, for example maltcp://10.0.0.1:61616
    */
   public String getRootURI(String fullURI)
   {


### PR DESCRIPTION
"tcpip://" prefix is deprecated.
"maltcp://" is the correct URI prefix for TCPIP transport.